### PR TITLE
Fix typo in options

### DIFF
--- a/distrod/libs/src/container_org_image.rs
+++ b/distrod/libs/src/container_org_image.rs
@@ -29,7 +29,7 @@ pub struct ContainerOrgImageList;
 #[async_trait]
 impl DistroImageFetcher for ContainerOrgImageList {
     fn get_name(&self) -> &str {
-        "Download an image from linxcontainers.org"
+        "Download an image from linuxcontainers.org"
     }
 
     async fn fetch(&self) -> Result<DistroImageList> {


### PR DESCRIPTION
Fix a typo in options. It was written "linxcontainers.org" but the correct one is "linuxcontainers.org"