### PR TITLE
Allow failing when dropping privileges inside container

### DIFF
--- a/distrod/distrod-exec/src/main.rs
+++ b/distrod/distrod-exec/src/main.rs
@@ -78,7 +78,7 @@ where
 {
     log::debug!("distrod-exec: exec_command");
     let cred = get_real_credential().with_context(|| "Failed to get the real credential.")?;
-    cred.drop_privilege();
+    let _ = cred.try_drop_privilege();
 
     let path = CString::new(command.as_ref().as_os_str().as_bytes()).with_context(|| {
         format!(


### PR DESCRIPTION
Some programs like GDB launces a shell without additional privileges, so dropping the privileges can fail. In order to fix that allow failures when already running inside a container. 

Note, that I also tried another approach, testing if the effecting privileges are already correct, however it go unreasonably complex since 'getgroups' is a bit unspecified. And I think ignoring the failures gets the same end result. I also checked the bash source for a reference and they do check for matching privileges, but on the other hand they never call `setgroups` so they don't need to deal with that.

> It is unspecified whether the effective group ID of the calling
       process is included in the returned list.  (Thus, an application
       should also call [getegid(2)](https://man7.org/linux/man-pages/man2/getegid.2.html) and add or remove the resulting
       value.)

I also noticed that bash has a `-p`, privileged mode parameter that distrod should probably also support, but that's not implemented in this pull request.

> -p      Turn  on  privileged mode.  In this mode, the $ENV and $BASH_ENV files are not processed, shell
                      functions are not inherited from the environment, and the SHELLOPTS, BASHOPTS, CDPATH, and GLO‐
                      BIGNORE  variables,  if  they  appear in the environment, are ignored.  If the shell is started
                      with the effective user (group) id not equal to the real user (group) id, and the -p option  is
                      not supplied, these actions are taken and the effective user id is set to the real user id.  If
                      the -p option is supplied at startup, the effective user id is not reset.  Turning this  option
                      off causes the effective user and group ids to be set to the real user and group ids.

Fixes https://github.com/nullpo-head/wsl-distrod/issues/22