### PR TITLE
installer: Fix the installer crashes by a cp's failure

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,9 @@ update () {
 
 get_release_file() {
     if [ -n "$RELEASE_FILE" ]; then
-        cp "$RELEASE_FILE" opt_distrod.tar.gz
+        if [ "$(realpath "$RELEASE_FILE")" != "$(realpath opt_distrod.tar.gz)" ]; then
+            cp "$RELEASE_FILE" opt_distrod.tar.gz
+        fi
     else
         curl -L -O "${LATEST_RELEASE_URL}"
     fi


### PR DESCRIPTION
This PR fixes the installer crashing when `RELEASE_FILE` is the same location as `opt_distrod.tar.gz`.