### PR TITLE
Fix/build without root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -401,5 +401,10 @@ FodyWeavers.xsd
 
 ## Distrod
 
+# Old
 rootfs
 rootfs.tar.gz
+
+# Updated 2022-09-24
+opt_distrod.tar.gz
+distrod_root.tar.gz

--- a/.help.mk
+++ b/.help.mk
@@ -1,0 +1,26 @@
+# Adapted from https://gist.github.com/prwhite/8168133
+
+# COLORS
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+RESET  := $(shell tput -Txterm sgr0)
+
+
+TARGET_MAX_CHAR_NUM=20
+## Show help
+help:
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk '/^[a-zA-Z\-_0-9]+:/ { \
+		helpMessage = match(lastLine, /^## (.*)/); \
+		if (helpMessage) { \
+			helpCommand = substr($$1, 0, index($$1, ":")-1); \
+			helpMessage = substr(lastLine, RSTART + 3, RLENGTH); \
+			printf "  ${YELLOW}%-$(TARGET_MAX_CHAR_NUM)s${RESET} ${GREEN}%s${RESET}\n", helpCommand, helpMessage; \
+		} \
+	} \
+	{ lastLine = $$0 }' $(MAKEFILE_LIST)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,17 @@
 OUTPUT_ROOTFS_PATH ?= distrod/distrod_wsl_launcher/resources/distrod_root.tar.gz
 
-build: distrod-release
-
-rootfs: distrod-bins distrod/target/release/portproxy.exe
-	./distrod_packer/distrod_packer ./distrod $(OUTPUT_ROOTFS_PATH)
+## Make program and Linux opt_distrod.tar.gz release
+distrod: distrod-release
 
 distrod-release: distrod-bins distrod/target/release/portproxy.exe
 	./distrod_packer/distrod_packer ./distrod opt_distrod.tar.gz --pack-distrod-opt-dir
+
+## Make rootfs for installation from Windows
+rootfs: distrod-bins distrod/target/release/portproxy.exe
+	./distrod_packer/distrod_packer ./distrod $(OUTPUT_ROOTFS_PATH)
+
+## Make distrod and rootfs
+all: distrod rootfs
 
 distrod-bins:
 	cd distrod; cargo build --release -p distrod -p distrod-exec -p portproxy
@@ -28,11 +33,13 @@ integration-test-linux-all-distros:
 		 DISTRO_TO_TEST=$${distro} ./test_runner.sh run; \
 	done
 
+## Run tests on Linux
 test-linux: lint unit-test-linux integration-test-linux
 
 lint:
 	shellcheck install.sh
 
+## Remove build files
 clean:
 	cd distrod; cargo clean; cargo.exe clean
 
@@ -46,5 +53,8 @@ include windows.mk
 .PHONY: $(ROOTFS_PATH)
 endif
 
-.PHONY: build rootfs distrod-release distrod-bins lint clean\
+.PHONY: all distrod rootfs distrod-release distrod-bins lint clean\
         unit-test-linux enter-integration-test-linux integration-test-linux integration-test-linux-all-distros test-linux
+
+.DEFAULT_GOAL := help
+include .help.mk

--- a/distrod_packer/distrod_packer
+++ b/distrod_packer/distrod_packer
@@ -244,14 +244,13 @@ def make_distrod_distribution_dirs(work_dir: Path):
 def set_permissions(work_dir: Path):
     dir_to_back = os.getcwd()
     os.chdir(work_dir)
-    os.system("sudo chmod 755 .")
-    os.system("sudo chown -R root:root .")
+    os.system("chmod 755 .")
     os.chdir(dir_to_back)
 
 
 def set_suid(bin_path: Path):
-    os.system(f"sudo chmod u+s {bin_path}")
-    os.system(f"sudo chmod g+s {bin_path}")
+    os.system(f"chmod u+s {bin_path}")
+    os.system(f"chmod g+s {bin_path}")
 
 
 def copy_distrod_distribution_resources(work_dir: Path):
@@ -281,7 +280,7 @@ def run_cargo_about(workspace_path: Path, out_path: Path):
 def compress_entire_tree(tree: Path, output_path: Path):
     dir_to_back = os.getcwd()
     os.chdir(tree)
-    os.system("sudo tar czf compressed.tar.gz *")
+    os.system("tar --owner=root --group=root -czf compressed.tar.gz *")
     shutil.copy(tree.joinpath("compressed.tar.gz"), output_path)
     os.chdir(dir_to_back)
 
@@ -290,7 +289,7 @@ def make_dir_deletable(tree: Path):
     dir_to_back = os.getcwd()
     os.chdir(tree)
     # Let the directory able to be deleted
-    os.system("sudo chown -R $(whoami):$(whoami) .")
+    os.system("chown -R $(whoami):$(whoami) .")
     os.chdir(dir_to_back)
 
 


### PR DESCRIPTION
We don't need `sudo` or root privileges to create files belonging to root in a `.tar`. Requiring `sudo` to build can cause compatibility issues, extra difficulty building, and security risks. This branch modifies `distrod_packer` to pack the `opt_distrod.tar.gz` as a normal user.

`Makefile` has also been updated to print a basic help message when `make` is run. This shows as either `make` or `make help`. This was added to increase discoverability for new users, novices, and other potential contributors.

Further updates and cleanup of `distrod_packer` could be done following this change. Such as removing obsolete functions such as `make_dir_deletable`. This cleanup has not been done.