### PR TITLE
Fix/update install.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,16 @@ lint:
 clean:
 	cd distrod; cargo clean; cargo.exe clean
 
+## Install locally built opt_distrod.tar.gz distrobution. Use 'update' if this system is already running distrod.
+install: build
+	sudo ./install.sh install --release-file ./opt_distrod.tar.gz
+.PHONY: install
+
+## Update local install with built opt_distrod.tar.gz distrobution. Use 'install' if this system doesn't have distrod installed.
+update: build
+	sudo ./install.sh update --release-file ./opt_distrod.tar.gz
+.PHONY: update
+
 ifneq ($(shell uname -a | grep microsoft),)  # This is a WSL environment, which means you can run .exe
 ROOTFS_PATH = $(OUTPUT_ROOTFS_PATH)
 OUTPUT_PORT_PROXY_EXE_PATH = distrod/target/release/portproxy.exe


### PR DESCRIPTION
The `--release-file` flag isn't listed under the `install.sh` script's help, but is very useful for local development.

Help is updated to show this flag.

`install` and `update` build targets are also added to the `Makefile`. These are shortcuts to `install.sh` using the `--release-flag` to use the locally built version. Shortcuts for development.