### PR TITLE
Support systems where %LocalAppData% contains a space

### DIFF
--- a/distrod/distrod_wsl_launcher/src/main.rs
+++ b/distrod/distrod_wsl_launcher/src/main.rs
@@ -293,7 +293,7 @@ fn register_distribution<P: AsRef<Path>>(distro_name: &str, tar_gz_filename: P) 
             .arg("wsl")
             .arg("--import")
             .arg(distro_name)
-            .arg(format!("%LocalAppData%\\{}", distro_name))
+            .arg(format!("\"%LocalAppData%\\{}\"", distro_name))
             .arg(tar_gz_filename.as_ref());
         let mut child = cmd
             .spawn()
@@ -305,7 +305,7 @@ fn register_distribution<P: AsRef<Path>>(distro_name: &str, tar_gz_filename: P) 
             bail!(
                 "Failed: cmd.exe /C wsl --import {} {} {:#?}",
                 distro_name,
-                format!("%LocalAppData%\\{}", distro_name),
+                format!("\"%LocalAppData%\\{}\"", distro_name),
                 tar_gz_filename.as_ref()
             );
         }


### PR DESCRIPTION
This can happen when the user's full name is used as %USERPROFILE%.

Fixes: #72